### PR TITLE
Add secondary node group failover and continuous execution mode

### DIFF
--- a/cmd/bb_autoscaler/BUILD.bazel
+++ b/cmd/bb_autoscaler/BUILD.bazel
@@ -3,13 +3,17 @@ load("@rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "bb_autoscaler_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "autoscaler.go",
+        "main.go",
+    ],
     importpath = "github.com/buildbarn/bb-autoscaler/cmd/bb_autoscaler",
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/autoscaler",
         "//pkg/proto/configuration/bb_autoscaler",
         "@com_github_aws_aws_sdk_go_v2_service_autoscaling//:autoscaling",
+        "@com_github_aws_aws_sdk_go_v2_service_autoscaling//types",
         "@com_github_aws_aws_sdk_go_v2_service_eks//:eks",
         "@com_github_aws_aws_sdk_go_v2_service_eks//types",
         "@com_github_buildbarn_bb_storage//pkg/cloud/aws",

--- a/cmd/bb_autoscaler/autoscaler.go
+++ b/cmd/bb_autoscaler/autoscaler.go
@@ -1,0 +1,386 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	autoscaling_types "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+	"github.com/buildbarn/bb-autoscaler/pkg/autoscaler"
+	"github.com/buildbarn/bb-autoscaler/pkg/proto/configuration/bb_autoscaler"
+	"github.com/buildbarn/bb-storage/pkg/cloud/aws"
+	http_client "github.com/buildbarn/bb-storage/pkg/http/client"
+	"github.com/buildbarn/bb-storage/pkg/util"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1_apply "k8s.io/client-go/applyconfigurations/apps/v1"
+	metav1_apply "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Autoscaler adjusts the capacity of Amazon EC2 Auto Scaling Groups (ASG),
+// EKS Managed Node Groups, or Kubernetes Deployments based on Prometheus metrics.
+type Autoscaler struct {
+	configuration       *bb_autoscaler.ApplicationConfiguration
+	prometheusAPI       v1.API
+	autoScalingClient   *autoscaling.Client
+	eksClient           *eks.Client
+	kubernetesClientset *kubernetes.Clientset
+}
+
+// NewAutoscaler creates a new Autoscaler instance with all necessary clients
+// initialized based on the provided configuration.
+func NewAutoscaler(configuration *bb_autoscaler.ApplicationConfiguration) (*Autoscaler, error) {
+	a := &Autoscaler{
+		configuration: configuration,
+	}
+
+	// Prometheus client is always needed
+	prometheusRoundTripper, err := http_client.NewRoundTripperFromConfiguration(configuration.PrometheusHttpClient)
+	if err != nil {
+		return nil, util.StatusWrap(err, "Failed to create Prometheus HTTP client")
+	}
+	prometheusClient, err := api.NewClient(api.Config{
+		Address:      configuration.PrometheusEndpoint,
+		RoundTripper: prometheusRoundTripper,
+	})
+	if err != nil {
+		return nil, util.StatusWrap(err, "Error creating Prometheus client")
+	}
+	a.prometheusAPI = v1.NewAPI(prometheusClient)
+
+	// Initialize AWS and Kubernetes clients based on node group types
+	for _, nodeGroup := range configuration.NodeGroups {
+		switch nodeGroup.Kind.(type) {
+		case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName, *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
+			if a.autoScalingClient == nil {
+				cfg, err := aws.NewConfigFromConfiguration(configuration.AwsSession, "Autoscaling")
+				if err != nil {
+					return nil, util.StatusWrap(err, "Failed to create AWS session")
+				}
+				a.autoScalingClient = autoscaling.NewFromConfig(cfg)
+				a.eksClient = eks.NewFromConfig(cfg)
+			}
+		case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
+			if a.kubernetesClientset == nil {
+				config, err := rest.InClusterConfig()
+				if err != nil {
+					return nil, util.StatusWrap(err, "Failed to create Kubernetes client configuration")
+				}
+				a.kubernetesClientset, err = kubernetes.NewForConfig(config)
+				if err != nil {
+					return nil, util.StatusWrap(err, "Failed to create Kubernetes client")
+				}
+			}
+		default:
+			return nil, status.Error(codes.InvalidArgument, "No ASG, EKS managed node group, or Kubernetes deployment name specified")
+		}
+	}
+
+	return a, nil
+}
+
+// RunOnce executes a single autoscaling cycle: fetching metrics from Prometheus
+// and adjusting node group sizes accordingly.
+func (a *Autoscaler) RunOnce(ctx context.Context) error {
+	// Obtain desired number of workers from Prometheus.
+	log.Printf("[1/2] Fetching desired worker count from Prometheus by running query %#v", a.configuration.PrometheusQuery)
+	result, _, err := a.prometheusAPI.Query(ctx, a.configuration.PrometheusQuery, time.Now())
+	if err != nil {
+		return util.StatusWrap(err, "Error querying Prometheus")
+	}
+
+	// Parse the metrics returned by Prometheus and convert them to
+	// a map that's indexed by the platform.
+	vector := result.(model.Vector)
+	desiredWorkersMap := make(map[autoscaler.SizeClassQueueKey]float64, len(vector))
+	for _, sample := range vector {
+		sizeClassQueueKey, err := autoscaler.NewSizeClassQueueKeyFromMetric(sample.Metric)
+		if err != nil {
+			return util.StatusWrapf(err, "Metric %s", sample.Metric)
+		}
+
+		desiredWorkersMap[sizeClassQueueKey] = float64(sample.Value)
+	}
+
+	// Adjust node group and deployment sizes.
+	log.Print("[2/2] Adjusting desired capacity of ASGs")
+
+	for _, nodeGroup := range a.configuration.NodeGroups {
+		platform, _ := protojson.Marshal(nodeGroup.Platform)
+		log.Printf("Instance name prefix %#v platform %s size class %d", nodeGroup.InstanceNamePrefix, string(platform), nodeGroup.SizeClass)
+		workersPerCapacityUnit := nodeGroup.WorkersPerCapacityUnit
+		log.Print("Workers per capacity unit: ", workersPerCapacityUnit)
+
+		// Obtain the desired number of workers from the
+		// Prometheus metrics gathered previously.
+		desiredWorkers, ok := desiredWorkersMap[autoscaler.NewSizeClassQueueKeyFromConfiguration(
+			nodeGroup.InstanceNamePrefix,
+			nodeGroup.Platform,
+			nodeGroup.SizeClass,
+		)]
+		if ok {
+			log.Print("Desired number of workers: ", desiredWorkers)
+
+			// Obtain the minimum/maximum size of the ASG,
+			// so that we can clamp the desired capacity.
+			oldDesiredCapacity := int32(-1)
+			var minSize, maxSize int32
+			var primaryNodegroupOutput *eks.DescribeNodegroupOutput
+			switch kind := nodeGroup.Kind.(type) {
+			case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName:
+				output, err := a.autoScalingClient.DescribeAutoScalingGroups(
+					ctx,
+					&autoscaling.DescribeAutoScalingGroupsInput{
+						AutoScalingGroupNames: []string{kind.AutoScalingGroupName},
+					})
+				if err != nil {
+					return util.StatusWrapf(err, "Failed to obtain properties of ASG %#v", kind.AutoScalingGroupName)
+				}
+				if len(output.AutoScalingGroups) != 1 {
+					return status.Errorf(codes.FailedPrecondition, "Obtaining properties of ASG %#v returned %d entries", kind.AutoScalingGroupName, len(output.AutoScalingGroups))
+				}
+				asg := output.AutoScalingGroups[0]
+				oldDesiredCapacity = *asg.DesiredCapacity
+				minSize = *asg.MinSize
+				maxSize = *asg.MaxSize
+			case *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
+				var err error
+				primaryNodegroupOutput, err = a.eksClient.DescribeNodegroup(
+					ctx,
+					&eks.DescribeNodegroupInput{
+						ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
+						NodegroupName: &kind.EksManagedNodeGroup.NodeGroupName,
+					})
+				if err != nil {
+					return util.StatusWrapf(err, "Failed to obtain properties of EKS managed node group %#v in cluster %#v", kind.EksManagedNodeGroup.NodeGroupName, kind.EksManagedNodeGroup.ClusterName)
+				}
+				scalingConfig := primaryNodegroupOutput.Nodegroup.ScalingConfig
+				oldDesiredCapacity = *scalingConfig.DesiredSize
+				minSize = *scalingConfig.MinSize
+				maxSize = *scalingConfig.MaxSize
+			case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
+				minSize = kind.KubernetesDeployment.MinimumReplicas
+				maxSize = kind.KubernetesDeployment.MaximumReplicas
+			default:
+				panic("Incomplete switch on node group kind")
+			}
+			log.Print("Node group minimum size: ", minSize)
+			log.Print("Node group maximum size: ", maxSize)
+
+			// Translate the desired number of workers to
+			// the desired ASG capacity.
+			newDesiredCapacity := (int32(math.Ceil(desiredWorkers)) + workersPerCapacityUnit - 1) / workersPerCapacityUnit
+			if newDesiredCapacity < minSize {
+				newDesiredCapacity = minSize
+			}
+			if newDesiredCapacity > maxSize {
+				newDesiredCapacity = maxSize
+			}
+
+			// Apply the desired ASG capacity.
+			if newDesiredCapacity == oldDesiredCapacity {
+				log.Print("Leaving desired capacity at ", newDesiredCapacity)
+			} else {
+				if oldDesiredCapacity >= 0 {
+					log.Printf("Changing desired capacity from %d to %d", oldDesiredCapacity, newDesiredCapacity)
+				} else {
+					log.Printf("Changing desired capacity to %d", newDesiredCapacity)
+				}
+
+				switch kind := nodeGroup.Kind.(type) {
+				case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName:
+					if _, err := a.autoScalingClient.SetDesiredCapacity(ctx, &autoscaling.SetDesiredCapacityInput{
+						AutoScalingGroupName: &kind.AutoScalingGroupName,
+						DesiredCapacity:      &newDesiredCapacity,
+					}); err != nil {
+						return util.StatusWrapf(err, "Failed to set desired capacity of ASG %#v", kind.AutoScalingGroupName)
+					}
+				case *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
+					if _, err := a.eksClient.UpdateNodegroupConfig(ctx, &eks.UpdateNodegroupConfigInput{
+						ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
+						NodegroupName: &kind.EksManagedNodeGroup.NodeGroupName,
+						ScalingConfig: &types.NodegroupScalingConfig{
+							DesiredSize: &newDesiredCapacity,
+						},
+					}); err != nil {
+						return util.StatusWrapf(err, "Failed to set desired size of EKS managed node group %#v in cluster %#v", kind.EksManagedNodeGroup.NodeGroupName, kind.EksManagedNodeGroup.ClusterName)
+					}
+				case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
+					namespace := kind.KubernetesDeployment.Namespace
+					name := kind.KubernetesDeployment.Name
+					metaKind := "Deployment"
+					metaAPIVersion := "apps/v1"
+					if _, err := a.kubernetesClientset.
+						AppsV1().
+						Deployments(namespace).
+						Apply(
+							ctx,
+							&appsv1_apply.DeploymentApplyConfiguration{
+								TypeMetaApplyConfiguration: metav1_apply.TypeMetaApplyConfiguration{
+									Kind:       &metaKind,
+									APIVersion: &metaAPIVersion,
+								},
+								ObjectMetaApplyConfiguration: &metav1_apply.ObjectMetaApplyConfiguration{
+									Name:      &name,
+									Namespace: &namespace,
+									Annotations: map[string]string{
+										"kubernetes.io/change-cause": "replicas updated by bb_autoscaler",
+									},
+								},
+								Spec: &appsv1_apply.DeploymentSpecApplyConfiguration{
+									Replicas: &newDesiredCapacity,
+								},
+							},
+							metav1.ApplyOptions{
+								FieldManager: "bb_autoscaler",
+								Force:        true,
+							}); err != nil {
+						return util.StatusWrapf(err, "Failed to change number of replicas of Kubernetes deployment %#v in namespace %#v", name, namespace)
+					}
+				default:
+					panic("Incomplete switch on node group kind")
+				}
+			}
+
+			// Handle secondary node group if configured (currently only for EKS managed node groups)
+			if kind, ok := nodeGroup.Kind.(*bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup); ok {
+				if kind.EksManagedNodeGroup.SecondaryNodeGroupName != "" {
+					if err := a.handleSecondaryNodeGroup(ctx, kind, primaryNodegroupOutput, newDesiredCapacity); err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			log.Print("WARNING: Prometheus did not return a desired number of workers")
+		}
+	}
+	return nil
+}
+
+// handleSecondaryNodeGroup manages the secondary node group for failover scenarios.
+//   - When the primary EKS node group has health issues (degraded status or health issues),
+//     the secondary node group automatically scales up to fill the capacity gap.
+//   - When primary is healthy, secondary scales down to its minimum size.
+func (a *Autoscaler) handleSecondaryNodeGroup(
+	ctx context.Context,
+	kind *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup,
+	primaryNodegroupOutput *eks.DescribeNodegroupOutput,
+	newDesiredCapacity int32,
+) error {
+	log.Printf("Secondary node group configured: %#v", kind.EksManagedNodeGroup.SecondaryNodeGroupName)
+
+	// Check if primary node group has health issues
+	primaryHasIssues := false
+	if primaryNodegroupOutput.Nodegroup.Status == types.NodegroupStatusDegraded {
+		log.Printf("Primary node group %#v status is DEGRADED", kind.EksManagedNodeGroup.NodeGroupName)
+		primaryHasIssues = true
+	}
+	if primaryNodegroupOutput.Nodegroup.Health != nil && len(primaryNodegroupOutput.Nodegroup.Health.Issues) > 0 {
+		log.Printf("Primary node group %#v has %d health issue(s):", kind.EksManagedNodeGroup.NodeGroupName, len(primaryNodegroupOutput.Nodegroup.Health.Issues))
+		for _, issue := range primaryNodegroupOutput.Nodegroup.Health.Issues {
+			message := ""
+			if issue.Message != nil {
+				message = *issue.Message
+			}
+			log.Printf("  - Code: %v, Message: %s", issue.Code, message)
+		}
+		primaryHasIssues = true
+	}
+
+	// Get secondary node group configuration
+	secondaryOutput, err := a.eksClient.DescribeNodegroup(
+		ctx,
+		&eks.DescribeNodegroupInput{
+			ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
+			NodegroupName: &kind.EksManagedNodeGroup.SecondaryNodeGroupName,
+		})
+	if err != nil {
+		return util.StatusWrapf(err, "Failed to obtain properties of secondary EKS managed node group %#v in cluster %#v", kind.EksManagedNodeGroup.SecondaryNodeGroupName, kind.EksManagedNodeGroup.ClusterName)
+	}
+	secondaryScalingConfig := secondaryOutput.Nodegroup.ScalingConfig
+	secondaryMinSize := *secondaryScalingConfig.MinSize
+	secondaryMaxSize := *secondaryScalingConfig.MaxSize
+	secondaryOldDesired := *secondaryScalingConfig.DesiredSize
+
+	// Calculate secondary desired capacity based on primary health
+	var secondaryNewDesired int32
+	if primaryHasIssues {
+		// Primary has issues: query ASG to get actual in-service count
+		if primaryNodegroupOutput.Nodegroup.Resources == nil || len(primaryNodegroupOutput.Nodegroup.Resources.AutoScalingGroups) == 0 {
+			return status.Errorf(codes.FailedPrecondition, "No Auto Scaling Group found for primary node group %#v", kind.EksManagedNodeGroup.NodeGroupName)
+		}
+		primaryASGName := *primaryNodegroupOutput.Nodegroup.Resources.AutoScalingGroups[0].Name
+		log.Printf("Primary node group backed by ASG: %#v", primaryASGName)
+
+		primaryASGOutput, err := a.autoScalingClient.DescribeAutoScalingGroups(
+			ctx,
+			&autoscaling.DescribeAutoScalingGroupsInput{
+				AutoScalingGroupNames: []string{primaryASGName},
+			})
+		if err != nil {
+			return util.StatusWrapf(err, "Failed to describe ASG %#v for primary node group", primaryASGName)
+		}
+		if len(primaryASGOutput.AutoScalingGroups) != 1 {
+			return status.Errorf(codes.FailedPrecondition, "Expected 1 ASG but got %d for ASG name %#v", len(primaryASGOutput.AutoScalingGroups), primaryASGName)
+		}
+
+		primaryASG := primaryASGOutput.AutoScalingGroups[0]
+		primaryInService := int32(0)
+		for _, instance := range primaryASG.Instances {
+			if instance.LifecycleState == autoscaling_types.LifecycleStateInService {
+				primaryInService++
+			}
+		}
+		log.Printf("Primary ASG: Desired=%d, InService=%d", *primaryASG.DesiredCapacity, primaryInService)
+
+		// Scale up secondary to fill the gap
+		secondaryNewDesired = newDesiredCapacity - primaryInService
+		if secondaryNewDesired < 0 {
+			secondaryNewDesired = 0
+		}
+		log.Printf("Primary has issues. Primary in-service: %d, Total desired: %d, Secondary target: %d", primaryInService, newDesiredCapacity, secondaryNewDesired)
+	} else {
+		// Primary is healthy: scale down secondary to minimum
+		secondaryNewDesired = secondaryMinSize
+		log.Printf("Primary is healthy. Scaling secondary to minimum: %d", secondaryNewDesired)
+	}
+
+	// Clamp secondary to its min/max bounds
+	if secondaryNewDesired < secondaryMinSize {
+		secondaryNewDesired = secondaryMinSize
+	}
+	if secondaryNewDesired > secondaryMaxSize {
+		secondaryNewDesired = secondaryMaxSize
+	}
+
+	// Update secondary node group if needed
+	if secondaryNewDesired != secondaryOldDesired {
+		log.Printf("Changing secondary node group %#v desired capacity from %d to %d", kind.EksManagedNodeGroup.SecondaryNodeGroupName, secondaryOldDesired, secondaryNewDesired)
+		if _, err := a.eksClient.UpdateNodegroupConfig(ctx, &eks.UpdateNodegroupConfigInput{
+			ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
+			NodegroupName: &kind.EksManagedNodeGroup.SecondaryNodeGroupName,
+			ScalingConfig: &types.NodegroupScalingConfig{
+				DesiredSize: &secondaryNewDesired,
+			},
+		}); err != nil {
+			return util.StatusWrapf(err, "Failed to set desired size of secondary EKS managed node group %#v in cluster %#v", kind.EksManagedNodeGroup.SecondaryNodeGroupName, kind.EksManagedNodeGroup.ClusterName)
+		}
+	} else {
+		log.Printf("Leaving secondary node group %#v desired capacity at %d", kind.EksManagedNodeGroup.SecondaryNodeGroupName, secondaryNewDesired)
+	}
+
+	return nil
+}

--- a/cmd/bb_autoscaler/main.go
+++ b/cmd/bb_autoscaler/main.go
@@ -3,32 +3,15 @@ package main
 import (
 	"context"
 	"log"
-	"math"
 	"os"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
-	"github.com/aws/aws-sdk-go-v2/service/eks"
-	"github.com/aws/aws-sdk-go-v2/service/eks/types"
-	"github.com/buildbarn/bb-autoscaler/pkg/autoscaler"
 	"github.com/buildbarn/bb-autoscaler/pkg/proto/configuration/bb_autoscaler"
-	"github.com/buildbarn/bb-storage/pkg/cloud/aws"
-	http_client "github.com/buildbarn/bb-storage/pkg/http/client"
 	"github.com/buildbarn/bb-storage/pkg/program"
 	"github.com/buildbarn/bb-storage/pkg/util"
-	"github.com/prometheus/client_golang/api"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	appsv1_apply "k8s.io/client-go/applyconfigurations/apps/v1"
-	metav1_apply "k8s.io/client-go/applyconfigurations/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // bb_autoscaler: Automatically adjust the capacity of Amazon EC2 Auto
@@ -36,8 +19,11 @@ import (
 //
 // This utility can be used to automatically scale the number of
 // Buildbarn workers based on queue size metrics exposed by
-// bb_scheduler. It is intended to run periodically (e.g., through a
-// Kubernetes cron job).
+// bb_scheduler. It supports two execution modes:
+//   - One-shot mode: Runs once and exits (suitable for Kubernetes cron jobs).
+//     This is the default when execution_interval_seconds is not set.
+//   - Continuous mode: Runs indefinitely at a configured interval when
+//     execution_interval_seconds is set to a positive value.
 //
 // This tool is written in such a way that it almost literally takes the
 // values obtained from Prometheus and uses those as the desired ASG
@@ -55,209 +41,42 @@ func main() {
 			return util.StatusWrapf(err, "Failed to read configuration from %s", os.Args[1])
 		}
 
-		// Obtain desired number of workers from Prometheus.
-		log.Printf("[1/2] Fetching desired worker count from Prometheus by running query %#v", configuration.PrometheusQuery)
-		prometheusRoundTripper, err := http_client.NewRoundTripperFromConfiguration(configuration.PrometheusHttpClient)
+		autoscaler, err := NewAutoscaler(&configuration)
 		if err != nil {
-			return util.StatusWrap(err, "Failed to create Prometheus HTTP client")
-		}
-		prometheusClient, err := api.NewClient(api.Config{
-			Address:      configuration.PrometheusEndpoint,
-			RoundTripper: prometheusRoundTripper,
-		})
-		if err != nil {
-			return util.StatusWrap(err, "Error creating Prometheus client")
-		}
-		v1api := v1.NewAPI(prometheusClient)
-		result, _, err := v1api.Query(ctx, configuration.PrometheusQuery, time.Now())
-		if err != nil {
-			return util.StatusWrap(err, "Error querying Prometheus")
+			return err
 		}
 
-		// Parse the metrics returned by Prometheus and convert them to
-		// a map that's indexed by the platform.
-		vector := result.(model.Vector)
-		desiredWorkersMap := make(map[autoscaler.SizeClassQueueKey]float64, len(vector))
-		for _, sample := range vector {
-			sizeClassQueueKey, err := autoscaler.NewSizeClassQueueKeyFromMetric(sample.Metric)
-			if err != nil {
-				return util.StatusWrapf(err, "Metric %s", sample.Metric)
-			}
-
-			desiredWorkersMap[sizeClassQueueKey] = float64(sample.Value)
+		// Determine if we should run once or indefinitely
+		executionInterval := time.Duration(configuration.ExecutionIntervalSeconds) * time.Second
+		if executionInterval <= 0 {
+			// One-shot mode
+			return autoscaler.RunOnce(ctx)
 		}
 
-		// Construct clients needed to adjust node group and
-		// deployment sizes.
-		log.Print("[2/2] Adjusting desired capacity of ASGs")
-		var autoScalingClient *autoscaling.Client
-		var eksClient *eks.Client
-		var kubernetesClientset *kubernetes.Clientset
-		for _, nodeGroup := range configuration.NodeGroups {
-			switch nodeGroup.Kind.(type) {
-			case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName, *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
-				if autoScalingClient == nil {
-					cfg, err := aws.NewConfigFromConfiguration(configuration.AwsSession, "Autoscaling")
-					if err != nil {
-						return util.StatusWrap(err, "Failed to create AWS session")
-					}
-					autoScalingClient = autoscaling.NewFromConfig(cfg)
-					eksClient = eks.NewFromConfig(cfg)
-				}
-			case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
-				if kubernetesClientset == nil {
-					config, err := rest.InClusterConfig()
-					if err != nil {
-						return util.StatusWrap(err, "Failed to create Kubernetes client configuration")
-					}
-					kubernetesClientset, err = kubernetes.NewForConfig(config)
-					if err != nil {
-						return util.StatusWrap(err, "Failed to create Kubernetes client")
-					}
-				}
-			default:
-				return status.Error(codes.InvalidArgument, "No ASG, EKS managed node group, or Kubernetes deployment name specified")
-			}
-		}
-
-		for _, nodeGroup := range configuration.NodeGroups {
-			platform, _ := protojson.Marshal(nodeGroup.Platform)
-			log.Printf("Instance name prefix %#v platform %s size class %d", nodeGroup.InstanceNamePrefix, string(platform), nodeGroup.SizeClass)
-			workersPerCapacityUnit := nodeGroup.WorkersPerCapacityUnit
-			log.Print("Workers per capacity unit: ", workersPerCapacityUnit)
-
-			// Obtain the desired number of workers from the
-			// Prometheus metrics gathered previously.
-			desiredWorkers, ok := desiredWorkersMap[autoscaler.NewSizeClassQueueKeyFromConfiguration(
-				nodeGroup.InstanceNamePrefix,
-				nodeGroup.Platform,
-				nodeGroup.SizeClass,
-			)]
-			if ok {
-				log.Print("Desired number of workers: ", desiredWorkers)
-
-				// Obtain the minimum/maximum size of the ASG,
-				// so that we can clamp the desired capacity.
-				oldDesiredCapacity := int32(-1)
-				var minSize, maxSize int32
-				switch kind := nodeGroup.Kind.(type) {
-				case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName:
-					output, err := autoScalingClient.DescribeAutoScalingGroups(
-						ctx,
-						&autoscaling.DescribeAutoScalingGroupsInput{
-							AutoScalingGroupNames: []string{kind.AutoScalingGroupName},
-						})
-					if err != nil {
-						return util.StatusWrapf(err, "Failed to obtain properties of ASG %#v", kind.AutoScalingGroupName)
-					}
-					if len(output.AutoScalingGroups) != 1 {
-						return status.Errorf(codes.FailedPrecondition, "Obtaining properties of ASG %#v returned %d entries", kind.AutoScalingGroupName, len(output.AutoScalingGroups))
-					}
-					asg := output.AutoScalingGroups[0]
-					oldDesiredCapacity = *asg.DesiredCapacity
-					minSize = *asg.MinSize
-					maxSize = *asg.MaxSize
-				case *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
-					output, err := eksClient.DescribeNodegroup(
-						ctx,
-						&eks.DescribeNodegroupInput{
-							ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
-							NodegroupName: &kind.EksManagedNodeGroup.NodeGroupName,
-						})
-					if err != nil {
-						return util.StatusWrapf(err, "Failed to obtain properties of EKS managed node group %#v in cluster %#v: %s", kind.EksManagedNodeGroup.NodeGroupName, kind.EksManagedNodeGroup.ClusterName)
-					}
-					scalingConfig := output.Nodegroup.ScalingConfig
-					oldDesiredCapacity = *scalingConfig.DesiredSize
-					minSize = *scalingConfig.MinSize
-					maxSize = *scalingConfig.MaxSize
-				case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
-					minSize = kind.KubernetesDeployment.MinimumReplicas
-					maxSize = kind.KubernetesDeployment.MaximumReplicas
-				default:
-					panic("Incomplete switch on node group kind")
-				}
-				log.Print("Node group minimum size: ", minSize)
-				log.Print("Node group maximum size: ", maxSize)
-
-				// Translate the desired number of workers to
-				// the desired ASG capacity.
-				newDesiredCapacity := (int32(math.Ceil(desiredWorkers)) + workersPerCapacityUnit - 1) / workersPerCapacityUnit
-				if newDesiredCapacity < minSize {
-					newDesiredCapacity = minSize
-				}
-				if newDesiredCapacity > maxSize {
-					newDesiredCapacity = maxSize
-				}
-
-				// Apply the desired ASG capacity.
-				if newDesiredCapacity == oldDesiredCapacity {
-					log.Print("Leaving desired capacity at ", newDesiredCapacity)
-				} else {
-					if oldDesiredCapacity >= 0 {
-						log.Printf("Changing desired capacity from %d to %d", oldDesiredCapacity, newDesiredCapacity)
-					} else {
-						log.Printf("Changing desired capacity to %d", newDesiredCapacity)
-					}
-
-					switch kind := nodeGroup.Kind.(type) {
-					case *bb_autoscaler.NodeGroupConfiguration_AutoScalingGroupName:
-						if _, err := autoScalingClient.SetDesiredCapacity(ctx, &autoscaling.SetDesiredCapacityInput{
-							AutoScalingGroupName: &kind.AutoScalingGroupName,
-							DesiredCapacity:      &newDesiredCapacity,
-						}); err != nil {
-							return util.StatusWrapf(err, "Failed to set desired capacity of ASG %#v", kind.AutoScalingGroupName)
-						}
-					case *bb_autoscaler.NodeGroupConfiguration_EksManagedNodeGroup:
-						if _, err := eksClient.UpdateNodegroupConfig(ctx, &eks.UpdateNodegroupConfigInput{
-							ClusterName:   &kind.EksManagedNodeGroup.ClusterName,
-							NodegroupName: &kind.EksManagedNodeGroup.NodeGroupName,
-							ScalingConfig: &types.NodegroupScalingConfig{
-								DesiredSize: &newDesiredCapacity,
-							},
-						}); err != nil {
-							return util.StatusWrapf(err, "Failed to set desired size of EKS managed node group %#v in cluster %#v: %s", kind.EksManagedNodeGroup.NodeGroupName, kind.EksManagedNodeGroup.ClusterName)
-						}
-					case *bb_autoscaler.NodeGroupConfiguration_KubernetesDeployment:
-						namespace := kind.KubernetesDeployment.Namespace
-						name := kind.KubernetesDeployment.Name
-						metaKind := "Deployment"
-						metaAPIVersion := "apps/v1"
-						if _, err := kubernetesClientset.
-							AppsV1().
-							Deployments(namespace).
-							Apply(
-								ctx,
-								&appsv1_apply.DeploymentApplyConfiguration{
-									TypeMetaApplyConfiguration: metav1_apply.TypeMetaApplyConfiguration{
-										Kind:       &metaKind,
-										APIVersion: &metaAPIVersion,
-									},
-									ObjectMetaApplyConfiguration: &metav1_apply.ObjectMetaApplyConfiguration{
-										Name:      &name,
-										Namespace: &namespace,
-										Annotations: map[string]string{
-											"kubernetes.io/change-cause": "replicas updated by bb_autoscaler",
-										},
-									},
-									Spec: &appsv1_apply.DeploymentSpecApplyConfiguration{
-										Replicas: &newDesiredCapacity,
-									},
-								},
-								metav1.ApplyOptions{
-									FieldManager: "bb_autoscaler",
-									Force:        true,
-								}); err != nil {
-							return util.StatusWrapf(err, "Failed to change number of replicas of Kubernetes deployment %#v in namespace %#v", name, namespace)
-						}
-					default:
-						panic("Incomplete switch on node group kind")
-					}
+		// Continuous mode - reuses the same autoscaler instance
+		log.Printf("Running autoscaler indefinitely with interval of %v", executionInterval)
+		const maxConsecutiveFailures = 5
+		consecutiveFailures := 0
+		for {
+			if err := autoscaler.RunOnce(ctx); err != nil {
+				consecutiveFailures++
+				log.Printf("Error in autoscaler (%d/%d consecutive failures): %v", consecutiveFailures, maxConsecutiveFailures, err)
+				if consecutiveFailures >= maxConsecutiveFailures {
+					return util.StatusWrapf(err, "Exiting after %d consecutive failures", consecutiveFailures)
 				}
 			} else {
-				log.Print("WARNING: Prometheus did not return a desired number of workers")
+				if consecutiveFailures > 0 {
+					log.Printf("Recovered after %d consecutive failure(s)", consecutiveFailures)
+				}
+				consecutiveFailures = 0
+			}
+
+			log.Printf("Waiting %v until next execution", executionInterval)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(executionInterval):
 			}
 		}
-		return nil
 	})
 }

--- a/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.pb.go
+++ b/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.pb.go
@@ -25,14 +25,15 @@ const (
 )
 
 type ApplicationConfiguration struct {
-	state                protoimpl.MessageState    `protogen:"open.v1"`
-	PrometheusHttpClient *client.Configuration     `protobuf:"bytes,5,opt,name=prometheus_http_client,json=prometheusHttpClient,proto3" json:"prometheus_http_client,omitempty"`
-	PrometheusEndpoint   string                    `protobuf:"bytes,1,opt,name=prometheus_endpoint,json=prometheusEndpoint,proto3" json:"prometheus_endpoint,omitempty"`
-	PrometheusQuery      string                    `protobuf:"bytes,2,opt,name=prometheus_query,json=prometheusQuery,proto3" json:"prometheus_query,omitempty"`
-	NodeGroups           []*NodeGroupConfiguration `protobuf:"bytes,3,rep,name=node_groups,json=nodeGroups,proto3" json:"node_groups,omitempty"`
-	AwsSession           *aws.SessionConfiguration `protobuf:"bytes,4,opt,name=aws_session,json=awsSession,proto3" json:"aws_session,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	state                    protoimpl.MessageState    `protogen:"open.v1"`
+	PrometheusHttpClient     *client.Configuration     `protobuf:"bytes,5,opt,name=prometheus_http_client,json=prometheusHttpClient,proto3" json:"prometheus_http_client,omitempty"`
+	PrometheusEndpoint       string                    `protobuf:"bytes,1,opt,name=prometheus_endpoint,json=prometheusEndpoint,proto3" json:"prometheus_endpoint,omitempty"`
+	PrometheusQuery          string                    `protobuf:"bytes,2,opt,name=prometheus_query,json=prometheusQuery,proto3" json:"prometheus_query,omitempty"`
+	NodeGroups               []*NodeGroupConfiguration `protobuf:"bytes,3,rep,name=node_groups,json=nodeGroups,proto3" json:"node_groups,omitempty"`
+	AwsSession               *aws.SessionConfiguration `protobuf:"bytes,4,opt,name=aws_session,json=awsSession,proto3" json:"aws_session,omitempty"`
+	ExecutionIntervalSeconds int32                     `protobuf:"varint,6,opt,name=execution_interval_seconds,json=executionIntervalSeconds,proto3" json:"execution_interval_seconds,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ApplicationConfiguration) Reset() {
@@ -100,12 +101,20 @@ func (x *ApplicationConfiguration) GetAwsSession() *aws.SessionConfiguration {
 	return nil
 }
 
+func (x *ApplicationConfiguration) GetExecutionIntervalSeconds() int32 {
+	if x != nil {
+		return x.ExecutionIntervalSeconds
+	}
+	return 0
+}
+
 type EKSManagedNodeGroupConfiguration struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ClusterName   string                 `protobuf:"bytes,1,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
-	NodeGroupName string                 `protobuf:"bytes,2,opt,name=node_group_name,json=nodeGroupName,proto3" json:"node_group_name,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                  protoimpl.MessageState `protogen:"open.v1"`
+	ClusterName            string                 `protobuf:"bytes,1,opt,name=cluster_name,json=clusterName,proto3" json:"cluster_name,omitempty"`
+	NodeGroupName          string                 `protobuf:"bytes,2,opt,name=node_group_name,json=nodeGroupName,proto3" json:"node_group_name,omitempty"`
+	SecondaryNodeGroupName string                 `protobuf:"bytes,3,opt,name=secondary_node_group_name,json=secondaryNodeGroupName,proto3" json:"secondary_node_group_name,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *EKSManagedNodeGroupConfiguration) Reset() {
@@ -148,6 +157,13 @@ func (x *EKSManagedNodeGroupConfiguration) GetClusterName() string {
 func (x *EKSManagedNodeGroupConfiguration) GetNodeGroupName() string {
 	if x != nil {
 		return x.NodeGroupName
+	}
+	return ""
+}
+
+func (x *EKSManagedNodeGroupConfiguration) GetSecondaryNodeGroupName() string {
+	if x != nil {
+		return x.SecondaryNodeGroupName
 	}
 	return ""
 }
@@ -354,7 +370,7 @@ var File_github_com_buildbarn_bb_autoscaler_pkg_proto_configuration_bb_autoscale
 
 const file_github_com_buildbarn_bb_autoscaler_pkg_proto_configuration_bb_autoscaler_bb_autoscaler_proto_rawDesc = "" +
 	"\n" +
-	"\\github.com/buildbarn/bb-autoscaler/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.proto\x12%buildbarn.configuration.bb_autoscaler\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"\x9a\x03\n" +
+	"\\github.com/buildbarn/bb-autoscaler/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.proto\x12%buildbarn.configuration.bb_autoscaler\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"\xd8\x03\n" +
 	"\x18ApplicationConfiguration\x12h\n" +
 	"\x16prometheus_http_client\x18\x05 \x01(\v22.buildbarn.configuration.http.client.ConfigurationR\x14prometheusHttpClient\x12/\n" +
 	"\x13prometheus_endpoint\x18\x01 \x01(\tR\x12prometheusEndpoint\x12)\n" +
@@ -362,10 +378,12 @@ const file_github_com_buildbarn_bb_autoscaler_pkg_proto_configuration_bb_autosca
 	"\vnode_groups\x18\x03 \x03(\v2=.buildbarn.configuration.bb_autoscaler.NodeGroupConfigurationR\n" +
 	"nodeGroups\x12X\n" +
 	"\vaws_session\x18\x04 \x01(\v27.buildbarn.configuration.cloud.aws.SessionConfigurationR\n" +
-	"awsSession\"m\n" +
+	"awsSession\x12<\n" +
+	"\x1aexecution_interval_seconds\x18\x06 \x01(\x05R\x18executionIntervalSeconds\"\xa8\x01\n" +
 	" EKSManagedNodeGroupConfiguration\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12&\n" +
-	"\x0fnode_group_name\x18\x02 \x01(\tR\rnodeGroupName\"\xab\x01\n" +
+	"\x0fnode_group_name\x18\x02 \x01(\tR\rnodeGroupName\x129\n" +
+	"\x19secondary_node_group_name\x18\x03 \x01(\tR\x16secondaryNodeGroupName\"\xab\x01\n" +
 	"!KubernetesDeploymentConfiguration\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12)\n" +

--- a/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.proto
+++ b/pkg/proto/configuration/bb_autoscaler/bb_autoscaler.proto
@@ -49,6 +49,14 @@ message ApplicationConfiguration {
   // when 'node_groups' contains one or more entries for AWS EC2 Auto
   // Scaling Groups (ASGs) or EKS Managed Node Groups.
   buildbarn.configuration.cloud.aws.SessionConfiguration aws_session = 4;
+
+  // Interval in seconds at which the autoscaler should execute. When set
+  // to a positive value, the autoscaler will run indefinitely, executing
+  // the autoscaling logic at this interval. If not set or set to zero,
+  // the autoscaler runs once and exits (suitable for running as a cron job).
+  //
+  // Example: 300 for 5 minutes
+  int32 execution_interval_seconds = 6;
 }
 
 message EKSManagedNodeGroupConfiguration {
@@ -57,6 +65,10 @@ message EKSManagedNodeGroupConfiguration {
 
   // Name of the managed node group in the EKS cluster.
   string node_group_name = 2;
+
+  // Optional: Secondary node group that scales up to fill capacity gaps
+  // when the primary has health issues (e.g., spot capacity shortage).
+  string secondary_node_group_name = 3;
 }
 
 message KubernetesDeploymentConfiguration {


### PR DESCRIPTION
## Key Changes

### 1. New Continuous Execution Mode
- Added `execution_interval_seconds` configuration option
- When set to a positive value, the autoscaler runs indefinitely at the specified interval
- When not set or zero, it runs once and exits (original cron job behavior)
- Includes error tolerance: exits after 5 consecutive failures

### 2. Secondary Node Group Failover Support
- Added `secondary_node_group_name` field to `EKSManagedNodeGroupConfiguration`
- **Enables maximizing spot instance usage while automatically failing over to on-demand instances when spot capacity is unavailable**
- When the primary EKS node group (spot instances) has health issues (degraded status or capacity shortage), the secondary node group (on-demand instances) automatically scales up to fill the capacity gap
- When primary is healthy, secondary scales down to its minimum size to minimize costs

### 3. Code Refactoring
- Extracted autoscaling logic from `main.go` into a new `autoscaler.go` file
- Created an `Autoscaler` struct that holds reusable clients (Prometheus, AWS, Kubernetes)
- `NewAutoscaler()` constructor initializes all clients once
- `RunOnce()` method executes a single autoscaling cycle
- Prevents resource leaks from recreating HTTP clients in continuous mode

### Files Changed
| File | Change |
|------|--------|
| `cmd/bb_autoscaler/autoscaler.go` | **New file** with `Autoscaler` struct. Holds reusable clients (Prometheus, AWS, Kubernetes). Prevents resource leaks from recreating HTTP clients in continuous mode |
| `cmd/bb_autoscaler/main.go` | Simplified to use `Autoscaler` |
| `pkg/proto/.../bb_autoscaler.proto` | Added new config fields |
| `cmd/bb_autoscaler/BUILD.bazel` | Added new source and dependency |